### PR TITLE
fix: update canonical URLs to remove 'www' for SEO consistency

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -13,4 +13,4 @@ Allow: /
 User-agent: *
 Allow: /
 
-Sitemap: https://www.atlantisndt.com/sitemap.xml
+Sitemap: https://atlantisndt.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,63 +3,63 @@
   xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
   <url>
-    <loc>https://www.atlantisndt.com/</loc>
+    <loc>https://atlantisndt.com/</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/about</loc>
+    <loc>https://atlantisndt.com/about</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/services</loc>
+    <loc>https://atlantisndt.com/services</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/training</loc>
+    <loc>https://atlantisndt.com/training</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/consulting-service</loc>
+    <loc>https://atlantisndt.com/consulting-service</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/contact</loc>
+    <loc>https://atlantisndt.com/contact</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/digital-twins</loc>
+    <loc>https://atlantisndt.com/digital-twins</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/erp</loc>
+    <loc>https://atlantisndt.com/erp</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/ndt-connect</loc>
+    <loc>https://atlantisndt.com/ndt-connect</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -67,49 +67,49 @@
 
   <!-- Blog index + posts -->
   <url>
-    <loc>https://www.atlantisndt.com/blog</loc>
+    <loc>https://atlantisndt.com/blog</loc>
     <lastmod>2025-10-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/blog/ultrasonic-testing</loc>
+    <loc>https://atlantisndt.com/blog/ultrasonic-testing</loc>
     <lastmod>2025-10-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/blog/magnetic-particle-testing</loc>
+    <loc>https://atlantisndt.com/blog/magnetic-particle-testing</loc>
     <lastmod>2025-10-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/blog/visual-testing</loc>
+    <loc>https://atlantisndt.com/blog/visual-testing</loc>
     <lastmod>2025-10-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/blog/radiographic-testing</loc>
+    <loc>https://atlantisndt.com/blog/radiographic-testing</loc>
     <lastmod>2025-10-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/blog/eddy-current-testing</loc>
+    <loc>https://atlantisndt.com/blog/eddy-current-testing</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.atlantisndt.com/blog/penetrant-testing</loc>
+    <loc>https://atlantisndt.com/blog/penetrant-testing</loc>
     <lastmod>2025-10-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -112,7 +112,7 @@ export default function About() {
          <SEOHead
             title="About Us"
             description="Learn about Atlantis NDT - Leading provider of Non-Destructive Testing services with 50+ certified professionals and Level III qualifications. Over 50 years of collective experience in oil & gas, marine, aerospace, and nuclear industries."
-            canonical="https://www.atlantisndt.com/about"
+            canonical="https://atlantisndt.com/about"
          />
 
          {/* Hero Section */}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -57,7 +57,7 @@ export default function BlogPage() {
             title="NDT Connect Blog"
             description="Read the latest insights, guides, and tutorials on Non-Destructive Testing techniques, technologies, and industry trends."
             keywords="NDT Connect blog, ultrasonic testing, radiographic testing, magnetic particle testing, visual testing, eddy current, penetrant testing, digital twins"
-            canonical="https://www.atlantisndt.com/blog"
+            canonical="https://atlantisndt.com/blog"
          />
 
          {/* Hero Section */}

--- a/src/pages/ConsultingServices.tsx
+++ b/src/pages/ConsultingServices.tsx
@@ -77,7 +77,7 @@ export default function ConsultingServices() {
             description="Expert Level III NDT consulting services including training, audits, quality assurance, and compliance for advanced inspection programs."
             keywords="Level III NDT consulting, NDT audit, NDT training, ASNT Level III, ISO 9712 consulting, NDT quality assurance"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/consulting-service"
+            canonical="https://atlantisndt.com/consulting-service"
          />
 
          {/* Hero Section */}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -138,7 +138,7 @@ export default function Contact() {
             description="Contact Atlantis NDT for professional Non-Destructive Testing services. Expert team providing 24/7 support across North America."
             keywords="contact NDT services, Atlantis NDT contact, NDT inspection quote, professional NDT consulting"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/contact"
+            canonical="https://atlantisndt.com/contact"
          />
 
          {/* Hero Section */}

--- a/src/pages/DigitalTwins.tsx
+++ b/src/pages/DigitalTwins.tsx
@@ -44,7 +44,7 @@ export default function DigitalTwins() {
                description="Explore our advanced Digital Twins technology for industrial applications. Interactive 3D models for training, simulation, and analysis of complex mechanical systems including jet engines, industrial plants, and equipment."
                keywords="digital twins, 3D models, industrial simulation, jet engine simulation, factory simulation, industrial training, mechanical systems, interactive models, virtual training, engineering visualization"
                ogImage="/atlantis.jpg"
-               canonical="https://www.atlantisndt.com/digital-twins"
+               canonical="https://atlantisndt.com/digital-twins"
             />
          <Navigation />
 

--- a/src/pages/Erp.tsx
+++ b/src/pages/Erp.tsx
@@ -120,7 +120,7 @@ export default function Erp() {
             description="Comprehensive ERP platform including inventory, sales, accounting, HR, and project management modules for businesses of all sizes."
             keywords="ERP software, business management, Odoo alternative, inventory, sales, finance, HR, project management"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/erp"
+            canonical="https://atlantisndt.com/erp"
          />
 
          {/* Hero Section */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,7 +21,7 @@ export default function Index() {
       "@type": "Organization",
       name: "Atlantis NDT",
       url: "https://atlantisndt.com",
-      logo: "https://www.atlantisndt.com/logo.png",
+      logo: "https://atlantisndt.com/logo.png",
       description:
          "Leading provider of Non-Destructive Testing services, training, and consultancy with state-of-the-art equipment and certified methodologies.",
       address: {
@@ -117,7 +117,7 @@ export default function Index() {
             description="Atlantis NDT - Leading provider of Non-Destructive Testing services with 50+ certified professionals. Specializing in ultrasonic, radiographic, magnetic particle, and penetrant testing across oil & gas, marine, aerospace, and nuclear industries."
             keywords="NDT services, Non-Destructive Testing, ultrasonic testing, radiographic testing, magnetic particle testing, penetrant testing, eddy current testing, visual testing, asset integrity, quality assurance"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/"
+            canonical="https://atlantisndt.com/"
          />
          <Hero />
          <AnimatedStats />

--- a/src/pages/NDTConnect.tsx
+++ b/src/pages/NDTConnect.tsx
@@ -125,7 +125,7 @@ export default function NDTConnect() {
             description="NDT Connect platform providing advanced inspection services including ultrasonic, radiographic, magnetic particle, penetrant, eddy current, and visual testing."
             keywords="NDT Connect, non-destructive testing, ultrasonic testing, radiographic testing, magnetic particle, penetrant, eddy current, visual testing"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/ndt-connect"
+            canonical="https://atlantisndt.com/ndt-connect"
          />
 
          {/* Hero Section */}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -91,7 +91,7 @@ export default function Services() {
            description="Comprehensive Non-Destructive Testing services including ultrasonic, radiographic, magnetic particle, penetrant, eddy current, and visual testing. State-of-the-art equipment and certified methodologies."
            keywords="NDT services, ultrasonic testing, radiographic testing, magnetic particle testing, penetrant testing, eddy current testing, visual testing, non-destructive testing methods"
            structuredData={structuredData}
-           canonical="https://www.atlantisndt.com/services"
+           canonical="https://atlantisndt.com/services"
         />
         {/* Hero Section */}
         <motion.section

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -146,7 +146,7 @@ export default function Training() {
            description="Professional NDT training and certification programs in India. Level I, II, III courses in ultrasonic, radiographic, magnetic particle, penetrant, eddy current, and visual testing. VR/AR enhanced learning."
            keywords={`NDT training India, NDT certification India, ultrasonic training India, radiographic training India, Level I II III certification, VR AR training, hands-on NDT courses, ndt testing, non destructive testing, ultrasonic testing, ndt non destructive testing, destructive and non destructive testing, nondestructive examination, ultrasonic examination, ndt non destructive, ndt destructive testing, non destructive testing and destructive testing, destructive non destructive testing, destructive testing and non destructive testing, destructive and non destructive test, destructive and nondestructive, non destructive inspection, magnetic particle testing, non destructive evaluation, radiography testing, mpi testing, magnetic particle inspection test, magnetic inspection test, mp testing, eddy current testing, liquid penetrant testing, penetrant testing`}
            structuredData={structuredData}
-           canonical="https://www.atlantisndt.com/training"
+           canonical="https://atlantisndt.com/training"
         />
         {/* Hero Section */}
         <motion.section

--- a/src/pages/digital-twins-ndt.tsx
+++ b/src/pages/digital-twins-ndt.tsx
@@ -10,7 +10,7 @@ export default function DigitalTwinsNDT() {
          <SEOHead
             title="Digital Twins in NDT: Transforming Asset Management"
             description="Explore how digital twins and VR/AR technology improve NDT processes and training."
-            canonical="https://www.atlantisndt.com/digital-twins-ndt"
+            canonical="https://atlantisndt.com/digital-twins-ndt"
          />
 
          {/* Hero Section */}

--- a/src/pages/eddy-current-testing.tsx
+++ b/src/pages/eddy-current-testing.tsx
@@ -7,7 +7,7 @@ export default function EddyCurrentTesting() {
    const structuredData = {
       "@context": "https://schema.org",
         "@type": "WebPage",
-        "@id": "https://www.atlantisndt.com/eddy-current-testing",
+        "@id": "https://atlantisndt.com/eddy-current-testing",
    };
 
    const advantages = [
@@ -77,7 +77,7 @@ export default function EddyCurrentTesting() {
             description="Discover Eddy Current Testing (ECT), a precise Non-Destructive Testing method for detecting surface and near-surface defects. Learn about its advantages, applications, and best practices."
             keywords="Eddy Current Testing, NDT services, Non-Destructive Testing, ultrasonic testing, radiographic testing, magnetic particle testing, penetrant testing, quality assurance, asset integrity, heat exchanger inspection"
             structuredData={structuredData}
-              canonical="https://www.atlantisndt.com/blog/eddy-current-testing"
+              canonical="https://atlantisndt.com/blog/eddy-current-testing"
          />
 
          {/* Hero Section */}

--- a/src/pages/magnetic-particle-testing.tsx
+++ b/src/pages/magnetic-particle-testing.tsx
@@ -22,7 +22,7 @@ export default function MagneticParticleTesting() {
       datePublished: "2025-10-03",
       mainEntityOfPage: {
          "@type": "WebPage",
-         "@id": "https://www.atlantisndt.com/blog/magnetic-particle-testing",
+         "@id": "https://atlantisndt.com/blog/magnetic-particle-testing",
       },
    };
 
@@ -95,7 +95,7 @@ export default function MagneticParticleTesting() {
             description="Learn how Magnetic Particle Testing (MPT) identifies surface and near-surface flaws in ferromagnetic materials for welds, castings, and machinery."
             keywords="Magnetic Particle Testing, MPT, NDT, Non-Destructive Testing, weld inspection, magnetic inspection, surface defects"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/blog/magnetic-particle-testing"
+            canonical="https://atlantisndt.com/blog/magnetic-particle-testing"
          />
 
          {/* Hero Section */}

--- a/src/pages/penetrant-testing.tsx
+++ b/src/pages/penetrant-testing.tsx
@@ -14,7 +14,7 @@ export default function PenetrantTesting() {
       datePublished: "2025-10-12",
       mainEntityOfPage: {
          "@type": "WebPage",
-         "@id": "https://www.atlantisndt.com/blog/penetrant-testing",
+         "@id": "https://atlantisndt.com/blog/penetrant-testing",
       },
    };
 
@@ -86,7 +86,7 @@ export default function PenetrantTesting() {
             description="Explore Liquid Penetrant Testing (PT) for identifying surface-breaking defects in materials. Learn advantages, applications, and best practices."
             keywords="Penetrant Testing, Liquid Penetrant Testing, NDT, Non-Destructive Testing, surface defects, quality assurance, asset integrity"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/blog/penetrant-testing"
+            canonical="https://atlantisndt.com/blog/penetrant-testing"
          />
 
       

--- a/src/pages/radiographic-testing.tsx
+++ b/src/pages/radiographic-testing.tsx
@@ -23,7 +23,7 @@ export default function RadiographicTesting() {
       datePublished: "2025-10-07",
       mainEntityOfPage: {
          "@type": "WebPage",
-         "@id": "https://www.atlantisndt.com/blog/radiographic-testing",
+         "@id": "https://atlantisndt.com/blog/radiographic-testing",
       },
    };
 
@@ -105,7 +105,7 @@ export default function RadiographicTesting() {
             description="Explore Radiographic Testing (RT) using X-rays and gamma rays for detecting internal defects, ensuring weld quality, and maintaining industrial safety standards."
             keywords="Radiographic Testing, X-ray testing, gamma ray testing, NDT services, weld inspection, internal defect detection, industrial radiography, non-destructive testing, quality assurance, Atlantis NDT"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/blog/radiographic-testing"
+            canonical="https://atlantisndt.com/blog/radiographic-testing"
          />
 
          {/* Header Section */}

--- a/src/pages/ultrasonic-testing.tsx
+++ b/src/pages/ultrasonic-testing.tsx
@@ -14,7 +14,7 @@ export default function UltrasonicTesting() {
       datePublished: "2025-10-01",
       mainEntityOfPage: {
          "@type": "WebPage",
-         "@id": "https://www.atlantisndt.com/blog/ultrasonic-testing",
+         "@id": "https://atlantisndt.com/blog/ultrasonic-testing",
       },
    };
 
@@ -88,7 +88,7 @@ export default function UltrasonicTesting() {
             description="Explore how Ultrasonic Testing (UT) detects internal flaws using high-frequency sound waves. Learn about its advantages, applications, and best practices."
             keywords="Ultrasonic Testing, UT, NDT, Non-Destructive Testing, flaw detection, weld inspection, thickness measurement"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/blog/ultrasonic-testing"
+            canonical="https://atlantisndt.com/blog/ultrasonic-testing"
          />
 
          {/* Hero Section */}

--- a/src/pages/visual-testing.tsx
+++ b/src/pages/visual-testing.tsx
@@ -14,7 +14,7 @@ export default function VisualTesting() {
       datePublished: "2025-10-05",
       mainEntityOfPage: {
          "@type": "WebPage",
-         "@id": "https://www.atlantisndt.com/blog/visual-testing",
+         "@id": "https://atlantisndt.com/blog/visual-testing",
       },
    };
 
@@ -93,7 +93,7 @@ export default function VisualTesting() {
             description="Learn about Visual Testing (VT), the foundational NDT method using direct observation, cameras, and drones for industrial inspection."
             keywords="Visual Testing, VT, NDT, Non-Destructive Testing, visual inspection, borescope, videoscope, drone inspection"
             structuredData={structuredData}
-            canonical="https://www.atlantisndt.com/blog/visual-testing"
+            canonical="https://atlantisndt.com/blog/visual-testing"
          />
 
          {/* Hero Section */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all domain URLs across the site to use the canonical non-www format (atlantisndt.com instead of www.atlantisndt.com). Changes applied to page metadata, SEO configurations, site indexing files, and all published content pages for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->